### PR TITLE
Dialyzer spec changes to account for EEP-0018

### DIFF
--- a/src/neo4j.erl
+++ b/src/neo4j.erl
@@ -1364,19 +1364,16 @@ get_root(BaseURI) when is_binary(BaseURI) ->
       {error, {non_200_response, StatusCode, Body}};
     {ok, _, _, Client} ->
       {ok, Body} = hackney:body(Client),
-      case jiffy:decode(Body) of
-        {error, E1, E2} -> {error, {E1, E2}};
-        Root            ->
-          %% we add some links as these are not returned by neo4j
-          %% and we wouldn't want to recreate them over and over again
-          prepend([ {<<"base_uri">>, BaseURI}
-                  , {<<"relationship">>, <<BaseURI/binary, "relationship">>}
-                  , {<<"label">>, <<BaseURI/binary, "label">>}
-                  , {<<"labels">>, <<BaseURI/binary, "labels">>}
-                  , {<<"index">>, <<BaseURI/binary, "schema/index">>}
-                  , {<<"constraint">>, <<BaseURI/binary, "schema/constraint">>}]
-                 , Root)
-      end
+      Root = jiffy:decode(Body),
+      %% we add some links as these are not returned by neo4j
+      %% and we wouldn't want to recreate them over and over again
+      prepend([ {<<"base_uri">>, BaseURI}
+              , {<<"relationship">>, <<BaseURI/binary, "relationship">>}
+              , {<<"label">>, <<BaseURI/binary, "label">>}
+              , {<<"labels">>, <<BaseURI/binary, "labels">>}
+              , {<<"index">>, <<BaseURI/binary, "schema/index">>}
+              , {<<"constraint">>, <<BaseURI/binary, "schema/constraint">>}]
+             , Root)
   end.
 
 -spec create(binary()) -> {neo4j_type()} | {error, term()}.


### PR DESCRIPTION
After the switch to jiffy for JSON parsing, the specs needed
to be changed so that clients of the library could properly validate
their code through dialyzer. This change accounts for the
{property_list()} format that jiffy returns for JSON and iolist() instead
of binary() for encode operations.

jiffy:decode throws on error and doesn't return an error tuple. This
was causing dialyzer to throw warning. Fix is to remove the case to
check for error and let the throw propagate up.

Test

  - Ran dialyzer suite on repo - looks good.
  - Ran dialyzer on code using this library as dependency and calling
    through transcation functions and all look good.

